### PR TITLE
修复 无法执行help等指令

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 )
 
 func main() {
-	setting.Run()
 	args := os.Args
 	if args == nil || len(args) < 2 {
 		setting.Help()


### PR DESCRIPTION
如果提前执行setting.Run()则无法执行后面。